### PR TITLE
tempita

### DIFF
--- a/cython_lint.py
+++ b/cython_lint.py
@@ -366,10 +366,16 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover
     ret = 0
     for path in args.paths:
         _, ext = os.path.splitext(path)
-        if ext != '.pyx':
+        if ext == '.tp':
+            with open(path, encoding='utf-8') as fd:
+                content = fd.read()
+            content = Tempita.sub(content)
+            path = path[:-3]  # remove .tp suffix
+        elif ext == '.pyx':
+            with open(path, encoding='utf-8') as fd:
+                content = fd.read()
+        else:
             continue
-        with open(path, encoding='utf-8') as fd:
-            content = fd.read()
         try:
             ret |= _main(content, path)
         except CompileError:


### PR DESCRIPTION
@jjerphan it's pretty straightforward to run this on tempita files too

Running this on `scikit-learn` `main` branch gives
```
sklearn/metrics/_dist_metrics.pyx:17:36: 'exp' imported but unused
sklearn/metrics/_dist_metrics.pyx:21:38: 'ITYPE' imported but unused
sklearn/metrics/_pairwise_distances_reduction/_argkmin.pyx:190:26: 'jdx' defined but unused
sklearn/metrics/_pairwise_distances_reduction/_argkmin.pyx:289:29: 'Y_indices' defined but unused
sklearn/metrics/_pairwise_distances_reduction/_argkmin.pyx:434:22: 'thread_num' defined but unused
sklearn/metrics/_pairwise_distances_reduction/_argkmin.pyx:481:21: 'squared_dist_i_j' defined but unused
sklearn/metrics/_pairwise_distances_reduction/_argkmin.pyx:676:26: 'jdx' defined but unused
sklearn/metrics/_pairwise_distances_reduction/_argkmin.pyx:775:29: 'Y_indices' defined but unused
sklearn/metrics/_pairwise_distances_reduction/_argkmin.pyx:920:22: 'thread_num' defined but unused
sklearn/metrics/_pairwise_distances_reduction/_argkmin.pyx:967:21: 'squared_dist_i_j' defined but unused
sklearn/metrics/_pairwise_distances_reduction/_base.pyx:19:32: 'ITYPE' imported but unused
sklearn/metrics/_pairwise_distances_reduction/_gemm_term_computer.pyx:10:3: 'ColMajor' imported but unused
sklearn/metrics/_pairwise_distances_reduction/_gemm_term_computer.pyx:106:21: 'i' defined but unused
sklearn/metrics/_pairwise_distances_reduction/_gemm_term_computer.pyx:106:24: 'j' defined but unused
sklearn/metrics/_pairwise_distances_reduction/_gemm_term_computer.pyx:107:21: 'squared_dist_i_j' defined but unused
sklearn/metrics/_pairwise_distances_reduction/_gemm_term_computer.pyx:265:21: 'i' defined but unused
sklearn/metrics/_pairwise_distances_reduction/_gemm_term_computer.pyx:265:24: 'j' defined but unused
sklearn/metrics/_pairwise_distances_reduction/_gemm_term_computer.pyx:266:21: 'squared_dist_i_j' defined but unused
sklearn/metrics/_pairwise_distances_reduction/_radius_neighborhood.pyx:220:26: 'jdx' defined but unused
sklearn/metrics/_pairwise_distances_reduction/_radius_neighborhood.pyx:281:26: 'jdx' defined but unused
sklearn/metrics/_pairwise_distances_reduction/_radius_neighborhood.pyx:281:31: 'thread_num' defined but unused
sklearn/metrics/_pairwise_distances_reduction/_radius_neighborhood.pyx:281:43: 'idx_n_element' defined but unused
sklearn/metrics/_pairwise_distances_reduction/_radius_neighborhood.pyx:281:58: 'idx_current' defined but unused
sklearn/metrics/_pairwise_distances_reduction/_radius_neighborhood.pyx:441:22: 'thread_num' defined but unused
sklearn/metrics/_pairwise_distances_reduction/_radius_neighborhood.pyx:688:26: 'jdx' defined but unused
sklearn/metrics/_pairwise_distances_reduction/_radius_neighborhood.pyx:749:26: 'jdx' defined but unused
sklearn/metrics/_pairwise_distances_reduction/_radius_neighborhood.pyx:749:31: 'thread_num' defined but unused
sklearn/metrics/_pairwise_distances_reduction/_radius_neighborhood.pyx:749:43: 'idx_n_element' defined but unused
sklearn/metrics/_pairwise_distances_reduction/_radius_neighborhood.pyx:749:58: 'idx_current' defined but unused
sklearn/metrics/_pairwise_distances_reduction/_radius_neighborhood.pyx:909:22: 'thread_num' defined but unused
sklearn/utils/_seq_dataset.pyx:9:9: 'cython' imported but unused
sklearn/utils/_seq_dataset.pyx:334:9: 'cython' imported but unused
sklearn/utils/_weight_vector.pyx:12:9: 'cython' imported but unused
sklearn/utils/_weight_vector.pyx:121:21: 'average_a' defined but unused
sklearn/utils/_weight_vector.pyx:294:20: 'average_a' defined but unused
```

If this would be useful to you I can make a release with it, it's really not much extra complexity