### PR TITLE
fix: remove warning emitted by setuptools

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ long_description_content_type = text/markdown
 url = https://github.com/MarcoGorelli/cython-lint
 author = Marco Gorelli
 license = MIT
-license_file = LICENSE
+license_files = LICENSE
 classifiers =
     License :: OSI Approved :: MIT License
     Programming Language :: Python :: 3


### PR DESCRIPTION
python-setuptools complains about a deprecated parameter, as shown by the following output:

```sh
/usr/lib/python3.10/site-packages/setuptools/config/setupcfg.py:508: SetuptoolsDeprecationWarning: The license_file parameter is deprecated, use license_files instead.
```

Fixes #48.