### PR TITLE
ENH Add support for config files

### DIFF
--- a/.github/workflows/latest_cython.yml
+++ b/.github/workflows/latest_cython.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.11"]
-        os: [windows-latest, ubuntu-18.04]
+        os: [windows-latest, ubuntu-latest]
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
-        os: [windows-latest, ubuntu-18.04]
+        os: [windows-latest, ubuntu-latest]
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/README.md
+++ b/README.md
@@ -71,6 +71,15 @@ as well as the following command-line arguments:
 - ``--files`` to pass a Regex pattern with which to match files to include;
 - ``--exclude`` to pass a Regex pattern with which to match files to exclude.
 
+Configuration can be set project-wise in a `pyproject.toml` file at the root of the project.
+Here's an example `pyproject.toml`:
+```
+[tool.cython-lint]
+max-line-length = 88
+ignore = ['E503', 'E504']
+exclude = 'my_project/excluded_cython_file.pyx'
+```
+
 ## Which checks are implemented?
 
 - assert statement with tuple condition (always true...)

--- a/cython_lint/cython_lint.py
+++ b/cython_lint/cython_lint.py
@@ -869,8 +869,8 @@ def _get_config(paths: list[pathlib.Path]) -> dict[str, Any]:
             config_parser = configparser.ConfigParser()
             config_parser.read(config_file)
             if config_parser.has_section('cython-lint'):
-                config = config_parser.items('cython-lint')
-                return {key: value for key, value in config}
+                config_items = config_parser.items('cython-lint')
+                return {key: value for key, value in config_items}
 
         root = root.parent
 
@@ -912,8 +912,9 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover
 
     ret = 0
 
-    ignore = args.ignore if isinstance(args.ignore, list) else [args.ignore]
-    ignore = {code.strip() for s in ignore for code in s.split(',')}
+    if not isinstance(args.ignore, list):
+        args.ignore = [args.ignore]
+    ignore = {code.strip() for s in args.ignore for code in s.split(',')}
 
     for path in paths:
         if path.is_file():

--- a/cython_lint/cython_lint.py
+++ b/cython_lint/cython_lint.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import argparse
 import collections
-import configparser
 import copy
 import os
 import pathlib
@@ -20,7 +19,7 @@ from typing import NoReturn
 from typing import Sequence
 
 if sys.version_info >= (3, 11):  # pragma: no cover
-    import tomllib  
+    import tomllib
 else:
     import tomli as tomllib
 
@@ -849,27 +848,17 @@ def _get_config(paths: list[pathlib.Path]) -> dict[str, Any]:
     Search for a pyproject.toml or a setup.cfg file in common
     parent directories of the given list of paths.
     """
-    paths = [path.resolve() for path in paths]
     root = pathlib.Path(os.path.commonpath(paths))
     root = root.parent if root.is_file() else root
 
     while root != root.parent:
 
-        # Look for pyproject.toml first
         config_file = root / 'pyproject.toml'
         if config_file.is_file():
             config = tomllib.loads(config_file.read_text())
             config = config.get('tool', {}).get('cython-lint', {})
             if config:
                 return config
-
-        config_file = root / 'setup.cfg'
-        if config_file.is_file():
-            config_parser = configparser.ConfigParser()
-            config_parser.read(config_file)
-            if config_parser.has_section('cython-lint'):
-                config_items = config_parser.items('cython-lint')
-                return {key: value for key, value in config_items}
 
         root = root.parent
 
@@ -902,7 +891,7 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover
         help='Comma-separated list of pycodestyle error codes to ignore',
     )
     args = parser.parse_args(argv)
-    paths = [pathlib.Path(path) for path in args.paths]
+    paths = [pathlib.Path(path).resolve() for path in args.paths]
 
     # Update defaults from pyproject.toml or setup.cfg if present
     config = {k.replace('-', '_'): v for k, v in _get_config(paths).items()}

--- a/cython_lint/cython_lint.py
+++ b/cython_lint/cython_lint.py
@@ -845,8 +845,8 @@ def traverse(tree: ModuleNode) -> Iterator[NodeParent]:
 def _get_config(paths: list[pathlib.Path]) -> dict[str, Any]:
     """Get the configuration from a config file
 
-    Search for a pyproject.toml or a setup.cfg file in common
-    parent directories of the given list of paths.
+    Search for a pyproject.toml file in common parent directories
+    of the given list of paths.
     """
     root = pathlib.Path(os.path.commonpath(paths))
     root = root.parent if root.is_file() else root
@@ -893,7 +893,7 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover
     args = parser.parse_args(argv)
     paths = [pathlib.Path(path).resolve() for path in args.paths]
 
-    # Update defaults from pyproject.toml or setup.cfg if present
+    # Update defaults from pyproject.toml if present
     config = {k.replace('-', '_'): v for k, v in _get_config(paths).items()}
     parser.set_defaults(**config)
     args = parser.parse_args(argv)

--- a/cython_lint/cython_lint.py
+++ b/cython_lint/cython_lint.py
@@ -19,8 +19,8 @@ from typing import NamedTuple
 from typing import NoReturn
 from typing import Sequence
 
-if sys.version_info >= (3, 11):
-    import tomllib
+if sys.version_info >= (3, 11):  # pragma: no cover
+    import tomllib  
 else:
     import tomli as tomllib
 
@@ -851,8 +851,7 @@ def _get_config(paths: list[pathlib.Path]) -> dict[str, Any]:
     """
     paths = [path.resolve() for path in paths]
     root = pathlib.Path(os.path.commonpath(paths))
-    if not root.is_dir():
-        root = root.parent
+    root = root.parent if root.is_file() else root
 
     while root != root.parent:
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ install_requires =
     cython>=0.29.32
     pycodestyle
     tokenize-rt>=3.2.0
+    tomli;python_version<'3.11'
 python_requires = >=3.7
 
 [options.packages.find]

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -709,3 +709,35 @@ def test_config_file(
     main(['--ignore=""', file])
     out, _ = capsys.readouterr()
     assert 't.pyx:1:11: E701 multiple statements on one line' in out
+
+
+@pytest.mark.parametrize('config_file', ['pyproject.toml', 'setup.cfg'])
+def test_config_file_no_cython_lint(
+    tmpdir: Any, capsys: Any, config_file: str
+) -> None:
+    config_file = os.path.join(tmpdir, config_file)
+    with open(config_file, 'w') as fd:
+        # config file with no cython-lint section
+        fd.write('\n')
+
+    file = os.path.join(tmpdir, 't.pyx')
+    with open(file, 'w', encoding='utf-8') as fd:
+        fd.write('while True: pass\n')  # E701
+
+    main([file])
+    out, _ = capsys.readouterr()
+    assert 't.pyx:1:11: E701 multiple statements on one line' in out
+
+
+def test_no_config_file(tmpdir: Any, capsys: Any) -> None:
+    file = os.path.join(tmpdir, 't.pyx')
+    with open(file, 'w', encoding='utf-8') as fd:
+        fd.write('while True: pass\n')  # E701
+
+    main(['--ignore=E701', file])
+    out, _ = capsys.readouterr()
+    assert out == ''
+
+    main([file])
+    out, _ = capsys.readouterr()
+    assert 't.pyx:1:11: E701 multiple statements on one line' in out

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -681,11 +681,18 @@ def test_noop_old_cython(capsys: Any, src: str) -> None:
     assert ret == 0
 
 
-def test_config_file(tmpdir: Any) -> None:
-    config_file = os.path.join(tmpdir, 'pyproject.toml')
+@pytest.mark.parametrize(
+    'config_file, tool_name, ignore',
+    [
+        ('pyproject.toml', 'tool.cython-lint', '["E701"]'),
+        ('setup.cfg', 'cython-lint', 'E701'),
+    ]
+)
+def test_config_file(tmpdir: Any, config_file: str, tool_name: str, ignore: str) -> None:
+    config_file = os.path.join(tmpdir, config_file)
     with open(config_file, 'w') as fd:
-        fd.write('[tool.cython-lint]\n')
-        fd.write('ignore = ["E701"]\n')
+        fd.write(f'[{tool_name}]\n')
+        fd.write(f'ignore = {ignore}\n')
 
     file = os.path.join(tmpdir, 't.pyx')
     with open(file, 'w', encoding='utf-8') as fd:

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -688,7 +688,9 @@ def test_noop_old_cython(capsys: Any, src: str) -> None:
         ('setup.cfg', 'cython-lint', 'E701'),
     ]
 )
-def test_config_file(tmpdir: Any, config_file: str, tool_name: str, ignore: str) -> None:
+def test_config_file(
+    tmpdir: Any, config_file: str, tool_name: str, ignore: str
+) -> None:
     config_file = os.path.join(tmpdir, config_file)
     with open(config_file, 'w') as fd:
         fd.write(f'[{tool_name}]\n')

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 import os
-import subprocess
 from typing import Any
 
 import Cython
 import pytest
 
+from cython_lint.cython_lint import main
 from cython_lint.cython_lint import _main
 
 INCLUDE_FILE_0 = os.path.join('tests', 'data', 'foo.pxi')
@@ -689,7 +689,7 @@ def test_noop_old_cython(capsys: Any, src: str) -> None:
     ],
 )
 def test_config_file(
-    tmpdir: Any, config_file: str, tool_name: str, ignore: str
+    tmpdir: Any, capsys: Any, config_file: str, tool_name: str, ignore: str
 ) -> None:
     config_file = os.path.join(tmpdir, config_file)
     with open(config_file, 'w') as fd:
@@ -701,16 +701,11 @@ def test_config_file(
         fd.write('while True: pass\n')  # E701
 
     # config file is respected
-    output = subprocess.run(
-        f'cython-lint {file}', shell=True, text=True, capture_output=True,
-    )
-    assert output.stdout == ''
+    main([file])
+    out, _ = capsys.readouterr()
+    assert out == ''
 
     # Command line arguments take precedence over config file
-    output = subprocess.run(
-        f'cython-lint --ignore="" {file}',
-        shell=True,
-        text=True,
-        capture_output=True,
-    )
-    assert 't.pyx:1:11: E701 multiple statements on one line' in output.stdout
+    main(['--ignore=""', file])
+    out, _ = capsys.readouterr()
+    assert 't.pyx:1:11: E701 multiple statements on one line' in out

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{37,38,39,310}, docs, docs-links
+envlist = py{37,38,39,310,311}, docs, docs-links
 
 [testenv]
 deps =


### PR DESCRIPTION
Fixes #64

This PR adds the possibility to set the configuration either from ``pyproject.toml`` or from ``setup.cfg``.

I chose to support ``setup.cfg`` as well because I read a lot of discussion regarding the transition to pyproject.toml and it seems that it has not been adopted by a bunch of projects. The main reason I found was the issue that it automatically triggers isolated builds even when you want to install in editable mode. Since ``cython-lint`` is used exclusively by projects that do have some compilation, I thought it was more convenient to support ``setup.cfg``.
