### PR TITLE
do not emit unused warning for variables named `unused*`

### DIFF
--- a/cython_lint/cython_lint.py
+++ b/cython_lint/cython_lint.py
@@ -256,6 +256,7 @@ def visit_funcdef(
             and _def[0] != func_name
             and _def[0] not in [i[0] for i in args]
             and not _def[0].startswith('_')
+            and not _def[0].startswith('unused')
             and _def[0] not in global_names
         ):
 

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -14,6 +14,43 @@ INCLUDE_FILE_1 = os.path.join('tests', 'data', 'bar.pxi')
 
 
 @pytest.mark.parametrize(
+    'src',
+    [
+        (
+            'cdef bint foo():\n'
+            '    cdef int _\n'
+            '    cdef int _a\n'
+            '    cdef int unused\n'
+            '    cdef int unused_a\n'
+        ),
+        (
+            'cdef bint foo():\n'
+            '    cdef int _ = 1\n'
+            '    cdef int _a = 1\n'
+            '    cdef int unused = 1\n'
+            '    cdef int unused_a = 1\n'
+        ),
+        (
+            'cdef bint foo():\n'
+            '    cdef int _\n'
+            '    cdef int _a\n'
+            '    cdef int unused\n'
+            '    cdef int unused_a\n'
+            '    _ = 1\n'
+            '    _a = 1\n'
+            '    unused = 1\n'
+            '    unused_a = 1\n'
+        ),
+    ],
+)
+def test_named_unused(capsys: Any, src: str) -> None:
+    ret = _main(src, 't.py', ext='.pyx', no_pycodestyle=True)
+    out, _ = capsys.readouterr()
+    assert out == ''
+    assert ret == 0
+
+
+@pytest.mark.parametrize(
     'src, expected',
     [
         (


### PR DESCRIPTION
Cython has its own warning for unused variables, which is enabled with `-Wextra`. However, the warning does not trigger if the variable is named `_` or if the variable name starts with `unused`.