### PR TITLE
refactor: switch pycodestyle from subprocess to library API

### DIFF
--- a/cython_lint/cython_lint.py
+++ b/cython_lint/cython_lint.py
@@ -869,7 +869,7 @@ def run_pycodestyle(
     violations: list[tuple[int, int, str]],
     ignore: set[str],
 ) -> None:
-    class _Report(pycodestyle.BaseReport):
+    class _Report(pycodestyle.BaseReport):  # type: ignore[misc]
         def error(
             self,
             line_number: int,
@@ -877,7 +877,7 @@ def run_pycodestyle(
             text: str,
             check: Any,
         ) -> str | None:
-            code = super().error(line_number, offset, text, check)
+            code: str | None = super().error(line_number, offset, text, check)
             if code:
                 violations.append((line_number, offset + 1, text))
             return code

--- a/cython_lint/cython_lint.py
+++ b/cython_lint/cython_lint.py
@@ -7,7 +7,6 @@ import copy
 import os
 import pathlib
 import re
-import subprocess
 import sys
 import warnings
 from typing import TYPE_CHECKING
@@ -74,6 +73,7 @@ from Cython.Compiler.Nodes import Node
 from Cython.Compiler.Nodes import SingleAssignmentNode
 from Cython.Compiler.Nodes import StatListNode
 from Cython.Compiler.TreeFragment import parse_from_strings
+import pycodestyle
 from tokenize_rt import src_to_tokens
 from tokenize_rt import tokens_to_src
 
@@ -869,25 +869,38 @@ def run_pycodestyle(
     violations: list[tuple[int, int, str]],
     ignore: set[str],
 ) -> None:
-    output = subprocess.run(
-        [
-            "pycodestyle",
-            f"--ignore={','.join(PYCODESTYLE_CODES | ignore)}",
-            f"--max-line-length={line_length}",
-            "--format=%(row)d:%(col)d:%(code)s %(text)s",
-            filename,
-        ],
-        text=True,
-        capture_output=True,
-        check=False,
+    class _Report(pycodestyle.BaseReport):
+        def error(
+            self,
+            line_number: int,
+            offset: int,
+            text: str,
+            check: Any,
+        ) -> str | None:
+            code = super().error(line_number, offset, text, check)
+            if code:
+                violations.append((line_number, offset + 1, text))
+            return code
+
+    style = pycodestyle.StyleGuide(
+        max_line_length=line_length,
+        reporter=_Report,
+        # paths= seeds the parent-walk that finds tox.ini / setup.cfg
+        paths=[filename],
     )
-    extra_lines = output.stdout.splitlines()
-    for extra_line in extra_lines:
-        if re.search(r"^\d+:\d+:", extra_line) is None:
-            # could be an extra line with pycodestyle statistics
-            continue
-        _lineno, _col, message = extra_line.split(":", maxsplit=2)
-        violations.append((int(_lineno), int(_col), message))
+    # merge our codes with config-loaded ignores; passing ignore= as a kwarg
+    # would clobber the config.
+    config_ignore = set(style.options.ignore or ())
+    style.options.ignore = tuple(
+        sorted(
+            code
+            for code in config_ignore | PYCODESTYLE_CODES | ignore
+            # filter empty strings (from --ignore="") since they match every
+            # code as a prefix.
+            if code
+        )
+    )
+    style.check_files([filename])
 
 
 def _main(  # noqa: PLR0913

--- a/cython_lint/cython_lint.py
+++ b/cython_lint/cython_lint.py
@@ -34,6 +34,7 @@ with warnings.catch_warnings():
     from Cython import Tempita
     from Cython.Compiler.TreeFragment import StringParseContext
 import Cython
+import pycodestyle
 from Cython.Compiler.ExprNodes import AttributeNode
 from Cython.Compiler.ExprNodes import ComprehensionAppendNode
 from Cython.Compiler.ExprNodes import ComprehensionNode
@@ -73,7 +74,6 @@ from Cython.Compiler.Nodes import Node
 from Cython.Compiler.Nodes import SingleAssignmentNode
 from Cython.Compiler.Nodes import StatListNode
 from Cython.Compiler.TreeFragment import parse_from_strings
-import pycodestyle
 from tokenize_rt import src_to_tokens
 from tokenize_rt import tokens_to_src
 

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -485,6 +485,13 @@ def test_late_binding_closure(
             1,
         ),
         (
+            # empty string from --ignore="" must not suppress everything
+            {""},
+            "{0}:1:11: E701 multiple statements on one line (colon)\n"
+            "{0}:2:6: W291 trailing whitespace\n",
+            1,
+        ),
+        (
             {"W291"},
             "{0}:1:11: E701 multiple statements on one line (colon)\n",
             1,
@@ -503,14 +510,44 @@ def test_pycodestyle(
     with open(file, "w", encoding="utf-8") as fd:
         fd.write("while True: pass\n")  # E701
         fd.write("x = 1 \n")  # W291
-    with open(os.path.join(tmpdir, "tox.ini"), "w") as fd:
-        fd.write("[pycodestyle]\nstatistics=True\n")
     src = ""
     ret = _main(src, file, ext=".pxd", ignore=ignore)
     out, _ = capsys.readouterr()
 
     assert out == expected.format(file)
     assert ret == exp_ret
+
+
+@pytest.mark.parametrize(
+    "tox_ini",
+    [
+        "[pycodestyle]\nexclude = t.py\n",
+        "[pycodestyle]\nignore = E701\n",
+    ],
+)
+def test_pycodestyle_with_tox(tmpdir: Any, capsys: Any, tox_ini: str) -> None:
+    file = os.path.join(tmpdir, "t.py")
+    with open(file, "w", encoding="utf-8") as fd:
+        fd.write("while True: pass\n")  # would trigger E701
+    with open(os.path.join(tmpdir, "tox.ini"), "w") as fd:
+        fd.write(tox_ini)
+    ret = _main("", file, ext=".pxd")
+    out, _ = capsys.readouterr()
+    assert "E701" not in out
+    assert ret == 0
+
+
+def test_pycodestyle_with_tox_merge(tmpdir: Any, capsys: Any) -> None:
+    file = os.path.join(tmpdir, "t.py")
+    with open(file, "w", encoding="utf-8") as fd:
+        fd.write("while True: pass\n")  # E701
+        fd.write("x = 1 \n")  # W291
+    with open(os.path.join(tmpdir, "tox.ini"), "w") as fd:
+        fd.write("[pycodestyle]\nignore = W291\n")
+    ret = _main("", file, ext=".pxd", ignore={"E701"})
+    out, _ = capsys.readouterr()
+    assert out == ""
+    assert ret == 0
 
 
 @pytest.mark.skipif(
@@ -530,8 +567,6 @@ def test_pycodestyle_when_ast_parsing_fails(
     )
     with open(file, "w", encoding="utf-8") as fd:
         fd.write(src)
-    with open(os.path.join(tmpdir, "tox.ini"), "w") as fd:
-        fd.write("[pycodestyle]\nstatistics=True\n")
     ret = _main(src, file, ext=".pyx")
     out, _ = capsys.readouterr()
     assert f"Skipping file {file}, as it cannot be parsed. Error: CompileError" in out


### PR DESCRIPTION
As initially described in #181, let's just call the pycodestyle APIs directly rather than shelling out via `subprocess`.

## Follow-on simplifications

Since we're directly using the Reporter class to return and append to violations, this has two changes:

1. Don't need to detect and skip the extra lines with pycodestyle statistics from stdout
2. Don't need to test for said `statistics=True` in `test_pycodestyle` and `test_pycodestyle_when_ast_parsing_fails`

## Bug fix: tox.ini ignore handling

Added `test_pycodestyle_with_tox` to make sure that `tox.ini` settings (i.e. ignore, exclude) were being picked up.

The old subprocess approach matched pycodestyle's CLI semantics, where `--ignore` fully replaces config-loaded ignores. (i.e. `--ignore` would clobber ignores from `tox.ini`)

The approach in this PR just merges the user-provided `ignore: set[str]` and whatever config pycodestyle picked up (i.e. the initial `style.options.ignore` on load)

Question for the maintainer: Happy to flip this to match the existing behaviour (i.e. the `--ignore` clobber)

Small lift, code-wise: Adjust the `StyleGuide` construction, drop `test_pycodestyle_with_tox_merge`, and fix up `test_pycodestyle_with_tox`.

## No change: --ignore="" behaviour

Also explicitly handling the empty string being passed to `--ignore`; pycodestyle CLI would've stripped this out. Added a pytest parametrize argument to `test_pycodestyle` for this.

Closes #81