### PR TITLE
fix: nargs="+" for `args.path`

### DIFF
--- a/cython_lint/cython_lint.py
+++ b/cython_lint/cython_lint.py
@@ -978,7 +978,7 @@ def _get_config(paths: list[pathlib.Path]) -> dict[str, Any]:
 
 def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover
     parser = argparse.ArgumentParser()
-    parser.add_argument("paths", nargs="*")
+    parser.add_argument("paths", nargs="+")
     parser.add_argument(
         "--files",
         help="Regex pattern with which to match files to include",


### PR DESCRIPTION
Otherwise, `paths=[]` gets passed to `_get_config`, which would cause `os.path.commonpath` to freak out.

Closes #99