### PR TITLE
Migrate to using `collections.abc` instead of continuing to use some deprecated items in the `typing` module

### DIFF
--- a/cython_lint/cython_lint.py
+++ b/cython_lint/cython_lint.py
@@ -12,7 +12,6 @@ import sys
 import warnings
 from typing import TYPE_CHECKING
 from typing import Any
-from typing import Hashable
 from typing import NamedTuple
 from typing import NoReturn
 
@@ -76,6 +75,7 @@ from tokenize_rt import tokens_to_src
 from cython_lint import __version__
 
 if TYPE_CHECKING:
+    from collections.abc import Hashable
     from collections.abc import Iterator
     from collections.abc import Mapping
     from collections.abc import MutableMapping

--- a/cython_lint/cython_lint.py
+++ b/cython_lint/cython_lint.py
@@ -13,12 +13,8 @@ import warnings
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import Hashable
-from typing import Iterator
-from typing import Mapping
-from typing import MutableMapping
 from typing import NamedTuple
 from typing import NoReturn
-from typing import Sequence
 
 from Cython.Compiler.Errors import init_thread
 
@@ -80,6 +76,11 @@ from tokenize_rt import tokens_to_src
 from cython_lint import __version__
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from collections.abc import Mapping
+    from collections.abc import MutableMapping
+    from collections.abc import Sequence
+
     from Cython.Compiler.ModuleNode import ModuleNode
 
 CYTHON_VERSION = tuple(Cython.__version__.split("."))

--- a/cython_lint/string_fixer.py
+++ b/cython_lint/string_fixer.py
@@ -5,7 +5,10 @@ import io
 import re
 import sys
 import tokenize
-from typing import Sequence
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 
 def handle_match(token_text: str, *, never: bool) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,10 +34,10 @@ double-quote-cython-strings = "cython_lint.string_fixer:main"
 [tool.ruff]
 line-length = 90
 fix = true
-target-version = "py38"
+target-version = "py310"
 
 lint.select = [
-  "ALL",
+  "ALL", "UP"
 ]
 lint.ignore = [
   'A001',


### PR DESCRIPTION
I decided to make it so that some more deprecated items like `typing.Sequence` used `collections.abc.Sequence` instead since there are some modules in later versions of python such as __3.9__ and onwards that have some of these items marked as deprecated so I've migrated them on over to `collections.abc` instead while also making sure they remained inside of ruff's rules that are neatly laid out for me.
