### PR TITLE
Lint for intended inlining that won't actually happen

### DIFF
--- a/cython_lint/cython_lint.py
+++ b/cython_lint/cython_lint.py
@@ -110,7 +110,7 @@ else:  # pragma: no cover
 
 # If necessary, include fixes from https://github.com/cython/cython/pull/7832
 # so pxd files can be parsed.
-if CYTHON_VERSION > ("3",) and CYTHON_VERSION < ("3", "3", "0"):
+if CYTHON_VERSION > ("3", "2") and CYTHON_VERSION[-1] != "0a1":
     # The following code is copyright by the Cython authors under the Apache 2.0
     # license, see https://github.com/cython/cython/blob/master/LICENSE.txt
     def parse_from_strings(  # type: ignore  # noqa
@@ -129,8 +129,6 @@ if CYTHON_VERSION > ("3",) and CYTHON_VERSION < ("3", "3", "0"):
         from Cython.Compiler.Scanning import PyrexScanner  # noqa: PLC0415
         from Cython.Compiler.Scanning import StringSourceDescriptor  # noqa: PLC0415
 
-        if context is None:
-            context = StringParseContext(name)
         # Since source files carry an encoding, it makes sense in this context
         # to use a unicode string so that code fragments don't have to bother
         # with encoding. This means that test code passed in should not have an
@@ -159,13 +157,10 @@ if CYTHON_VERSION > ("3",) and CYTHON_VERSION < ("3", "3", "0"):
         )
         ctx = Parsing.Ctx(allow_struct_enum_decorator=allow_struct_enum_decorator)
 
-        if level is None or level == "module_pxd":
-            in_pxd = level == "module_pxd"
-            tree = Parsing.p_module(scanner, in_pxd, module_name, ctx=ctx)
-            tree.is_pxd = in_pxd
-        else:
-            scanner.parse_comments = False
-            tree = Parsing.p_code(scanner, level=level, ctx=ctx)
+        assert level is None or level == "module_pxd"
+        in_pxd = level == "module_pxd"
+        tree = Parsing.p_module(scanner, in_pxd, module_name, ctx=ctx)
+        tree.is_pxd = in_pxd
 
         tree.scope = scope
         return tree
@@ -268,6 +263,7 @@ class SharedState:
         self, filename: str, func_name: str, lineno: int, violations: Violations
     ) -> None:
         """Register a ``cdef inline`` in a .pyx/.py file."""
+        # This can sometimes happen from a .pxd.
         if filename.endswith(".pyx"):
             self._register_inline_cfunction_or_declaration(
                 True, filename, func_name, lineno, violations
@@ -676,9 +672,14 @@ def _traverse_file(  # noqa: PLR0915,PLR0913
     global_names: list[str] = []
     exported_imports: list[str] = []
 
-    _body: ExprNode = tree.body  # type: ignore[assignment]
+    if hasattr(tree, "body"):
+        # Older versions of Cython:
+        _body: ExprNode = tree.body  # type: ignore[assignment]
+    else:
+        # Cython 3.3.0a1 and later:
+        _body: ExprNode = tree
     if isinstance(_body, StatListNode):
-        _stats: list[StatNode] = tree.body.stats  # type: ignore[assignment]
+        _stats: list[StatNode] = _body.stats  # type: ignore[assignment]
         for node in _stats:
             if isinstance(node, StatListNode):
                 for _node in node.stats:

--- a/cython_lint/cython_lint.py
+++ b/cython_lint/cython_lint.py
@@ -650,7 +650,7 @@ def _traverse_file(  # noqa: PLR0915,PLR0913
     skip_check: only for when traversing an included file
     """
     try:
-        context = StringParseContext(filename)
+        context = StringParseContext(filename, cpp=True)
         context.set_language_level(3)
         init_thread()
         extra_kwargs = {}

--- a/cython_lint/cython_lint.py
+++ b/cython_lint/cython_lint.py
@@ -181,10 +181,13 @@ def err_msg(node: Node, expected: str) -> NoReturn:
     )
 
 
+Violations = list[tuple[int, int, str]]
+
+
 def visit_cvardef(
     node: CVarDefNode,
     lines: Mapping[int, str],
-    violations: list[tuple[int, int, str]],
+    violations: Violations,
 ) -> None:
     _base = lines[node.pos[1]][node.pos[2] :]
     round_parens = 0
@@ -216,7 +219,7 @@ def visit_funcdef(
     node: CFuncDefNode | DefNode,
     global_names: list[str],
     global_imports: list[Token],
-    violations: list[tuple[int, int, str]],
+    violations: Violations,
 ) -> None:
     children = [i.node for i in traverse(node)][1:]
 
@@ -357,7 +360,7 @@ def _record_imports(node: Node) -> Iterator[Token]:
 
 def visit_dict_node(
     node: DictNode,
-    violations: list[tuple[int, int, str]],
+    violations: Violations,
 ) -> None:
     literal_counts: MutableMapping[
         Hashable,
@@ -442,7 +445,7 @@ def _traverse_file(  # noqa: PLR0915,PLR0913
     lines: Mapping[int, str],
     *,
     skip_check: bool,
-    violations: list[tuple[int, int, str]] | None,
+    violations: Violations | None,
     ban_relative_imports: bool,
 ) -> tuple[list[Token], list[Token], list[str]]:
     """
@@ -905,7 +908,7 @@ def sanitise_input(
 def run_ast_checks(
     code: str,
     filename: str,
-    violations: list[tuple[int, int, str]],
+    violations: Violations,
     *,
     ban_relative_imports: bool,
 ) -> dict[int, str]:
@@ -957,7 +960,7 @@ def run_ast_checks(
 def run_pycodestyle(
     line_length: int,
     filename: str,
-    violations: list[tuple[int, int, str]],
+    violations: Violations,
     ignore: set[str],
 ) -> None:
     output = subprocess.run(
@@ -994,7 +997,7 @@ def _main(  # noqa: PLR0913
     if ignore is None:
         ignore = set()
     assert ignore is not None  # help mypy
-    violations: list[tuple[int, int, str]] = []
+    violations: Violations = []
     if not no_pycodestyle:
         run_pycodestyle(line_length, filename, violations, ignore)
 

--- a/cython_lint/cython_lint.py
+++ b/cython_lint/cython_lint.py
@@ -184,6 +184,62 @@ def err_msg(node: Node, expected: str) -> NoReturn:
 Violations = list[tuple[int, int, str]]
 
 
+class SharedState:
+    """Track state that involves multiple files."""
+
+    def __init__(self) -> None:
+        # Map (filename without extension, function_name) to
+        #     (filename, line number):
+        self._declared_functions: dict[tuple[str, str], tuple[str, int]] = {}
+        # Map (filename without extension, function_name) to
+        #     (filename, line number):
+        self._inline_cfunctions: dict[tuple[str, str], tuple[str, int]] = {}
+
+    def register_inline_cfunction(
+        self, filename: str, func_name: str, lineno: int, violations: Violations
+    ) -> None:
+        """Register a ``cdef inline`` in a .pyx/.py file."""
+        self._register_inline_cfunction_or_declaration(
+            True, filename, func_name, lineno, violations
+        )
+
+    def register_declaration(
+        self, filename: str, func_name: str, lineno: int, violations: Violations
+    ) -> None:
+        """Register a ``cdef`` declaration in a .pxd file."""
+        self._register_inline_cfunction_or_declaration(
+            False, filename, func_name, lineno, violations
+        )
+
+    def _register_inline_cfunction_or_declaration(
+        self,
+        is_inline_cfunction: bool,
+        filename: str,
+        func_name: str,
+        lineno: int,
+        violations: Violations,
+    ) -> None:
+        filename_without_ext, _ = os.path.splitext(filename)
+        if is_inline_cfunction:
+            to_add = self._inline_cfunctions
+        else:
+            to_add = self._declared_functions
+        key = (filename_without_ext, func_name)
+        to_add[key] = (filename, lineno)
+        if key in self._declared_functions and key in self._inline_cfunctions:
+            decl_filename, decl_lineno = self._declared_functions[key]
+            impl_filename, impl_lineno = self._inline_cfunctions[key]
+            message = (
+                f"C function '{func_name}' is declared in "
+                f"{decl_filename}:{decl_lineno}, and implemented "
+                f"and marked inline in {impl_filename}:{impl_lineno}. Inlining "
+                "will NOT happen across modules, the inline will be ignored. "
+                "If you want inlining, move the full implementation into "
+                f"{decl_filename}, instead of just declaring it there."
+            )
+            violations.append((lineno, 0, message))
+
+
 def visit_cvardef(
     node: CVarDefNode,
     lines: Mapping[int, str],
@@ -217,8 +273,10 @@ def visit_cvardef(
 
 def visit_funcdef(
     node: CFuncDefNode | DefNode,
+    filename: str,
     global_names: list[str],
     global_imports: list[Token],
+    shared_state: SharedState,
     violations: Violations,
 ) -> None:
     children = [i.node for i in traverse(node)][1:]
@@ -270,6 +328,10 @@ def visit_funcdef(
     if isinstance(node, CFuncDefNode):
         func = _func_from_base(node.declarator)
         func_name = _name_from_base(func.base).name
+        if "inline" in node.modifiers:
+            shared_state.register_inline_cfunction(
+                filename, func_name, node.pos[1], violations
+            )
     else:
         func_name = node.name
 
@@ -443,6 +505,7 @@ def _traverse_file(  # noqa: PLR0915,PLR0913
     code: str,
     filename: str,
     lines: Mapping[int, str],
+    shared_state: SharedState,
     *,
     skip_check: bool,
     violations: Violations | None,
@@ -504,9 +567,16 @@ def _traverse_file(  # noqa: PLR0915,PLR0913
         if isinstance(node, (CFuncDefNode, DefNode)):
             visit_funcdef(
                 node,
+                filename,
                 global_names,
                 global_imports,
+                shared_state,
                 violations=violations,
+            )
+
+        if isinstance(node, CFuncDeclaratorNode) and filename.endswith(".pxd"):
+            shared_state.register_declaration(
+                filename, node.declared_name(), node.pos[1], violations
             )
 
         if isinstance(node, CVarDefNode):
@@ -908,6 +978,7 @@ def sanitise_input(
 def run_ast_checks(
     code: str,
     filename: str,
+    shared_state: SharedState,
     violations: Violations,
     *,
     ban_relative_imports: bool,
@@ -917,6 +988,7 @@ def run_ast_checks(
         code,
         filename,
         lines,
+        shared_state,
         violations=violations,
         ban_relative_imports=ban_relative_imports,
         skip_check=False,
@@ -929,6 +1001,7 @@ def run_ast_checks(
             _code,
             filename,
             _lines,
+            shared_state,
             skip_check=True,
             violations=None,
             ban_relative_imports=False,
@@ -946,6 +1019,7 @@ def run_ast_checks(
             _import[0] not in [_name[0] for _name in names if _import != _name]
             and _import[0] not in [_name[0] for _name in included_names]
             and _import[0] not in exported_imports
+            and not filename.endswith(".pxd")
         ):
             violations.append(
                 (
@@ -987,6 +1061,7 @@ def run_pycodestyle(
 def _main(  # noqa: PLR0913
     code: str,
     filename: str,
+    shared_state: SharedState,
     *,
     ext: str,
     line_length: int = 88,
@@ -1002,10 +1077,14 @@ def _main(  # noqa: PLR0913
         run_pycodestyle(line_length, filename, violations, ignore)
 
     lines = {}
-    if ext == ".pyx":
+    if ext in (".pyx", ".pxd"):
         with contextlib.suppress(CythonParseError):
             lines = run_ast_checks(
-                code, filename, violations, ban_relative_imports=ban_relative_imports
+                code,
+                filename,
+                shared_state,
+                violations,
+                ban_relative_imports=ban_relative_imports,
             )
 
     ret = 0
@@ -1110,6 +1189,8 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover
         args.ignore = [args.ignore]
     ignore: set[str] = {code.strip() for s in args.ignore for code in s.split(",")}
 
+    shared_state = SharedState()
+
     for path in paths:
         if path.is_file():
             filepaths = iter((path,))
@@ -1133,6 +1214,7 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover
             ret |= _main(
                 content,
                 str(filepath),
+                shared_state,
                 line_length=args.max_line_length,
                 no_pycodestyle=args.no_pycodestyle,
                 ext=ext,

--- a/cython_lint/cython_lint.py
+++ b/cython_lint/cython_lint.py
@@ -57,6 +57,7 @@ from Cython.Compiler.ExprNodes import TupleNode
 from Cython.Compiler.ExprNodes import UnicodeNode
 from Cython.Compiler.Nodes import AssertStatNode
 from Cython.Compiler.Nodes import CArgDeclNode
+from Cython.Compiler.Nodes import CClassDefNode
 from Cython.Compiler.Nodes import CDeclaratorNode
 from Cython.Compiler.Nodes import CFuncDeclaratorNode
 from Cython.Compiler.Nodes import CFuncDefNode
@@ -399,7 +400,15 @@ def visit_funcdef(  # noqa: PLR0913
         _declarator: CDeclaratorNode = node.declarator  # type: ignore[assignment]
         func = _func_from_base(_declarator)
         func_name = _name_from_name_node(_name_from_base(func.base))  # type: ignore[attr-defined]
-        if "inline" in node.modifiers:
+        # Record inline stand-alone functions:
+        is_method = False
+        parent = node._cl_parent
+        while parent is not None:
+            if isinstance(parent, CClassDefNode):
+                is_method = True
+                break
+            parent = parent._cl_parent
+        if "inline" in node.modifiers and not is_method:
             shared_state.register_inline_cfunction(
                 filename, func_name, node.pos[1], violations
             )
@@ -679,6 +688,7 @@ def _traverse_file(  # noqa: PLR0915,PLR0913
     names: list[Token] = []
     for node_parent in nodes:
         node = node_parent.node
+        node._cl_parent = node_parent.parent
         imported_names.extend(_record_imports(node))
         if isinstance(node, GlobalNode):
             _names: list[str] = node.names  # type: ignore[assignment]

--- a/cython_lint/cython_lint.py
+++ b/cython_lint/cython_lint.py
@@ -112,18 +112,15 @@ else:  # pragma: no cover
 
 # If necessary, include fixes from https://github.com/cython/cython/pull/7832
 # so pxd files can be parsed.
-if CYTHON_VERSION > ("3", "2") and CYTHON_VERSION[-1] != "0a1":
+if CYTHON_VERSION > ("3", "2") and CYTHON_VERSION[-1] != "0a1":  # pragma: no cover
     # The following code is copyright by the Cython authors under the Apache 2.0
     # license, see https://github.com/cython/cython/blob/master/LICENSE.txt
     def parse_from_strings(  # type: ignore  # noqa
         name,  # noqa
         code,  # noqa
-        pxds=None,  # noqa
         level=None,  # noqa
-        initial_pos=None,  # noqa
         context=None,  # noqa
         allow_struct_enum_decorator=False,  # noqa
-        in_utility_code=False,  # noqa
     ):
         from io import StringIO  # noqa: PLC0415
 
@@ -139,11 +136,8 @@ if CYTHON_VERSION > ("3", "2") and CYTHON_VERSION[-1] != "0a1":
         encoding = "UTF-8"
 
         module_name = name
-        if initial_pos is None:
-            initial_pos = (name, 1, 0)
+        initial_pos = (name, 1, 0)
         code_source = StringSourceDescriptor(name, code)
-        if in_utility_code:
-            code_source.in_utility_code = True
 
         assert context is not None
         scope = context.find_module(module_name, pos=initial_pos, need_pxd=False)
@@ -677,10 +671,10 @@ def _traverse_file(  # noqa: PLR0915,PLR0913
 
     if hasattr(tree, "body"):
         # Older versions of Cython:
-        _body: ExprNode = tree.body  # type: ignore[assignment]
+        _body: ExprNode = tree.body  # type: ignore[assignment]   # pragma: no cover
     else:
         # Cython 3.3.0a1 and later:
-        _body: ExprNode = tree  # type: ignore[assignment]
+        _body: ExprNode = tree  # type: ignore[assignment]   # pragma: no cover
     if isinstance(_body, StatListNode):
         _stats: list[StatNode] = _body.stats  # type: ignore[assignment]
         for node in _stats:

--- a/cython_lint/cython_lint.py
+++ b/cython_lint/cython_lint.py
@@ -77,7 +77,9 @@ from Cython.Compiler.Nodes import Node
 from Cython.Compiler.Nodes import SingleAssignmentNode
 from Cython.Compiler.Nodes import StatListNode
 from Cython.Compiler.Nodes import StatNode
-from Cython.Compiler.TreeFragment import parse_from_strings
+from Cython.Compiler.TreeFragment import (
+    parse_from_strings,  # type: ignore[reportAssignmentType]
+)
 from tokenize_rt import src_to_tokens
 from tokenize_rt import tokens_to_src
 
@@ -143,6 +145,7 @@ if CYTHON_VERSION > ("3", "2") and CYTHON_VERSION[-1] != "0a1":
         if in_utility_code:
             code_source.in_utility_code = True
 
+        assert context is not None
         scope = context.find_module(module_name, pos=initial_pos, need_pxd=False)
 
         buf = StringIO(code)
@@ -159,10 +162,10 @@ if CYTHON_VERSION > ("3", "2") and CYTHON_VERSION[-1] != "0a1":
 
         assert level is None or level == "module_pxd"
         in_pxd = level == "module_pxd"
-        tree = Parsing.p_module(scanner, in_pxd, module_name, ctx=ctx)
-        tree.is_pxd = in_pxd
+        tree = Parsing.p_module(scanner, in_pxd, module_name, ctx=ctx)  # type: ignore[type]
+        tree.is_pxd = in_pxd  # type: ignore[missing-attribute]
 
-        tree.scope = scope
+        tree.scope = scope  # type: ignore[missing-attribute]
         return tree
 
 
@@ -398,7 +401,7 @@ def visit_funcdef(  # noqa: PLR0913
         func_name = _name_from_name_node(_name_from_base(func.base))  # type: ignore[attr-defined]
         # Record inline stand-alone functions:
         is_method = False
-        parent = node._cl_parent
+        parent = node._cl_parent  # type: ignore[missing-attribute]
         while parent is not None:
             if isinstance(parent, CClassDefNode):
                 is_method = True
@@ -677,7 +680,7 @@ def _traverse_file(  # noqa: PLR0915,PLR0913
         _body: ExprNode = tree.body  # type: ignore[assignment]
     else:
         # Cython 3.3.0a1 and later:
-        _body: ExprNode = tree
+        _body: ExprNode = tree  # type: ignore[assignment]
     if isinstance(_body, StatListNode):
         _stats: list[StatNode] = _body.stats  # type: ignore[assignment]
         for node in _stats:
@@ -689,7 +692,7 @@ def _traverse_file(  # noqa: PLR0915,PLR0913
     names: list[Token] = []
     for node_parent in nodes:
         node = node_parent.node
-        node._cl_parent = node_parent.parent
+        node._cl_parent = node_parent.parent  # type: ignore[assignment]
         imported_names.extend(_record_imports(node))
         if isinstance(node, GlobalNode):
             _names: list[str] = node.names  # type: ignore[assignment]

--- a/cython_lint/cython_lint.py
+++ b/cython_lint/cython_lint.py
@@ -215,7 +215,7 @@ class SharedState:
 
     def _register_inline_cfunction_or_declaration(
         self,
-        is_inline_cfunction: bool,
+        is_inline_cfunction: bool,  # noqa: FBT001
         filename: str,
         func_name: str,
         lineno: int,
@@ -273,7 +273,7 @@ def visit_cvardef(
         )
 
 
-def visit_funcdef(
+def visit_funcdef(  # noqa: PLR0913
     node: CFuncDefNode | DefNode,
     filename: str,
     global_names: list[str],

--- a/cython_lint/cython_lint.py
+++ b/cython_lint/cython_lint.py
@@ -102,6 +102,69 @@ else:  # pragma: no cover
         pass
 
 
+# If necessary, include fixes from https://github.com/cython/cython/pull/7832
+# so pxd files can be parsed.
+if CYTHON_VERSION > ("3",) and CYTHON_VERSION < ("3", "3", "0"):
+    # The following code is copyright by the Cython authors under the Apache 2.0
+    # license, see https://github.com/cython/cython/blob/master/LICENSE.txt
+    def parse_from_strings(  # type: ignore  # noqa
+        name,  # noqa
+        code,  # noqa
+        pxds=None,  # noqa
+        level=None,  # noqa
+        initial_pos=None,  # noqa
+        context=None,  # noqa
+        allow_struct_enum_decorator=False,  # noqa
+        in_utility_code=False,  # noqa
+    ):
+        from io import StringIO  # noqa: PLC0415
+
+        from Cython.Compiler import Parsing  # noqa: PLC0415
+        from Cython.Compiler.Scanning import PyrexScanner  # noqa: PLC0415
+        from Cython.Compiler.Scanning import StringSourceDescriptor  # noqa: PLC0415
+
+        if context is None:
+            context = StringParseContext(name)
+        # Since source files carry an encoding, it makes sense in this context
+        # to use a unicode string so that code fragments don't have to bother
+        # with encoding. This means that test code passed in should not have an
+        # encoding header.
+        assert isinstance(code, str), "unicode code snippets only please"
+        encoding = "UTF-8"
+
+        module_name = name
+        if initial_pos is None:
+            initial_pos = (name, 1, 0)
+        code_source = StringSourceDescriptor(name, code)
+        if in_utility_code:
+            code_source.in_utility_code = True
+
+        scope = context.find_module(module_name, pos=initial_pos, need_pxd=False)
+
+        buf = StringIO(code)
+
+        scanner = PyrexScanner(
+            buf,
+            code_source,
+            source_encoding=encoding,
+            scope=scope,
+            context=context,
+            initial_pos=initial_pos,
+        )
+        ctx = Parsing.Ctx(allow_struct_enum_decorator=allow_struct_enum_decorator)
+
+        if level is None or level == "module_pxd":
+            in_pxd = level == "module_pxd"
+            tree = Parsing.p_module(scanner, in_pxd, module_name, ctx=ctx)
+            tree.is_pxd = in_pxd
+        else:
+            scanner.parse_comments = False
+            tree = Parsing.p_code(scanner, level=level, ctx=ctx)
+
+        tree.scope = scope
+        return tree
+
+
 PRAGMA = r"#\s+no-cython-lint"
 
 # generate these with python generate_pycodestyle_codes.py
@@ -520,7 +583,10 @@ def _traverse_file(  # noqa: PLR0915,PLR0913
         context = StringParseContext(filename)
         context.set_language_level(3)
         init_thread()
-        tree = parse_from_strings(filename, code, context=context)
+        extra_kwargs = {}
+        if filename.endswith(".pxd"):
+            extra_kwargs["level"] = "module_pxd"
+        tree = parse_from_strings(filename, code, context=context, **extra_kwargs)
     except Exception as exp:  # pragma: no cover
         # If Cython can't parse this file, just skip it.
         print(

--- a/cython_lint/cython_lint.py
+++ b/cython_lint/cython_lint.py
@@ -199,17 +199,19 @@ class SharedState:
         self, filename: str, func_name: str, lineno: int, violations: Violations
     ) -> None:
         """Register a ``cdef inline`` in a .pyx/.py file."""
-        self._register_inline_cfunction_or_declaration(
-            True, filename, func_name, lineno, violations
-        )
+        if filename.endswith(".pyx"):
+            self._register_inline_cfunction_or_declaration(
+                True, filename, func_name, lineno, violations
+            )
 
     def register_declaration(
         self, filename: str, func_name: str, lineno: int, violations: Violations
     ) -> None:
         """Register a ``cdef`` declaration in a .pxd file."""
-        self._register_inline_cfunction_or_declaration(
-            False, filename, func_name, lineno, violations
-        )
+        if filename.endswith(".pxd"):
+            self._register_inline_cfunction_or_declaration(
+                False, filename, func_name, lineno, violations
+            )
 
     def _register_inline_cfunction_or_declaration(
         self,
@@ -574,7 +576,7 @@ def _traverse_file(  # noqa: PLR0915,PLR0913
                 violations=violations,
             )
 
-        if isinstance(node, CFuncDeclaratorNode) and filename.endswith(".pxd"):
+        if isinstance(node, CFuncDeclaratorNode):
             shared_state.register_declaration(
                 filename, node.declared_name(), node.pos[1], violations
             )

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
 import os
+from typing import TYPE_CHECKING
 from typing import Any
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 import Cython
 import pytest
 
-from cython_lint.cython_lint import _main, SharedState
+from cython_lint.cython_lint import SharedState
+from cython_lint.cython_lint import _main
 from cython_lint.cython_lint import main
 
 INCLUDE_FILE_0 = os.path.join("tests", "data", "foo.pxi")
@@ -107,9 +112,10 @@ def test_imported_unused(capsys: Any, src: str, expected: str) -> None:
     assert ret == 1
 
 
-def test_imported_unused_not_checked_in_pxd(capsys) -> None:
+@pytest.mark.parametrize("suffix", [".pxd", ".pxi"])
+def test_imported_unused_not_checked_in_pxd_and_pxi(capsys: Any, suffix: str) -> None:
     src = "from foo import bar, bar2\n"
-    ret = _main(src, "t.pxd", SharedState(), ext=".pxd")
+    ret = _main(src, "t." + suffix, SharedState(), ext=suffix)
     out, _ = capsys.readouterr()
     assert out == ""
     assert ret == 0
@@ -892,7 +898,7 @@ def test_unnecessary_dict_list_set(
     assert ret == 1
 
 
-def test_inline_pxd(tmp_path, capsys):
+def test_inline_pxd(tmp_path: Path, capsys: Any) -> None:
     pyx = str(tmp_path / "example.pyx")
     pxd = str(tmp_path / "example.pxd")
 

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -900,35 +900,65 @@ def test_unnecessary_dict_list_set(
 
 
 def test_inline_pxd(tmp_path: Path, capsys: Any) -> None:
-    pyx = str(tmp_path / "example.pyx")
     pxd = str(tmp_path / "example.pxd")
-
     with open(pxd, "w") as f:
         f.write("""\
-cdef int not_inline(int a)
+cdef int not_inline(self, int a)
 
-cdef int is_inline(int a)
+cdef int is_inline(self, int a)
 
-cdef inline int inline_in_pxd(int a):
+cdef inline int inline_in_pxd(self, int a):
     return a
+
+cdef class X:
+    cdef int inline_method(self, int a)
+
+    cdef int inline_final_method(self, int a)
+
+cdef class X2:
+    cdef int inline_in_final_class(self, int a)
 """)
 
+    pyx = str(tmp_path / "example.pyx")
     with open(pyx, "w") as f:
         f.write("""
-cdef int not_inline(int a):
+import cython
+
+cdef int not_inline(self, int a):
     return a
 
-cdef inline int is_inline(int a):
+cdef inline int is_inline(self, int a):
     return a
+
+cdef class X:
+    cdef inline int inline_method(self, int a):
+        return a
+
+    @cython.final
+    cdef inline int inline_final_method(self, int a):
+        return a
+
+@cython.final
+cdef class X2:
+    cdef inline int inline_in_final_class(self, int a):
+        return a
 """)
 
-    for ordered_files, lineno in [((pyx, pxd), 3), ((pxd, pyx), 5)]:
+    for ordered_files, lineno in [((pyx, pxd), 3), ((pxd, pyx), 7)]:
         main(ordered_files)
         out, _ = capsys.readouterr()
+        # Fully defined inline in the .pxd, so not a problem:
         assert "inline_in_pxd" not in out
+        # Not inlined anywhere, so not a problem:
         assert "not_inline" not in out
+        # We don't check methods, due to false positives because of
+        # inheritance; final isn't enforced across extension modules
+        # so can't rely on it, unfortunately.
+        assert "inline_method" not in out
+        assert "inline_final_method" not in out
+        assert "inline_method_final_class" not in out
         assert (
             f"{ordered_files[1]}:{lineno}:0: C function 'is_inline' "
             f"is declared in {pxd}:3, and implemented and marked inline in "
-            f"{pyx}:5."
+            f"{pyx}:7."
         ) in out

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -6,7 +6,7 @@ from typing import Any
 import Cython
 import pytest
 
-from cython_lint.cython_lint import _main
+from cython_lint.cython_lint import _main, SharedState
 from cython_lint.cython_lint import main
 
 INCLUDE_FILE_0 = os.path.join("tests", "data", "foo.pxi")
@@ -44,7 +44,7 @@ INCLUDE_FILE_1 = os.path.join("tests", "data", "bar.pxi")
     ],
 )
 def test_named_unused(capsys: Any, src: str) -> None:
-    ret = _main(src, "t.py", ext=".pyx", no_pycodestyle=True)
+    ret = _main(src, "t.py", SharedState(), ext=".pyx", no_pycodestyle=True)
     out, _ = capsys.readouterr()
     assert out == ""
     assert ret == 0
@@ -68,7 +68,7 @@ def test_named_unused(capsys: Any, src: str) -> None:
     ],
 )
 def test_assigned_unused(capsys: Any, src: str, expected: str) -> None:
-    ret = _main(src, "t.py", ext=".pyx", no_pycodestyle=True)
+    ret = _main(src, "t.py", SharedState(), ext=".pyx", no_pycodestyle=True)
     out, _ = capsys.readouterr()
     assert out == expected
     assert ret == 1
@@ -101,10 +101,18 @@ def test_assigned_unused(capsys: Any, src: str, expected: str) -> None:
     ],
 )
 def test_imported_unused(capsys: Any, src: str, expected: str) -> None:
-    ret = _main(src, "t.py", ext=".pyx")
+    ret = _main(src, "t.py", SharedState(), ext=".pyx")
     out, _ = capsys.readouterr()
     assert out == expected
     assert ret == 1
+
+
+def test_imported_unused_not_checked_in_pxd(capsys) -> None:
+    src = "from foo import bar, bar2\n"
+    ret = _main(src, "t.pxd", SharedState(), ext=".pxd")
+    out, _ = capsys.readouterr()
+    assert out == ""
+    assert ret == 0
 
 
 @pytest.mark.parametrize(
@@ -121,7 +129,7 @@ def test_imported_unused(capsys: Any, src: str, expected: str) -> None:
     ],
 )
 def test_useless_alias(capsys: Any, src: str, expected: str) -> None:
-    ret = _main(src, "t.py", ext=".pyx", no_pycodestyle=True)
+    ret = _main(src, "t.py", SharedState(), ext=".pyx", no_pycodestyle=True)
     out, _ = capsys.readouterr()
     assert out == expected
     assert ret == 1
@@ -149,12 +157,19 @@ def test_useless_alias(capsys: Any, src: str, expected: str) -> None:
     ],
 )
 def test_relative_import(capsys: Any, src: str, expected: str) -> None:
-    ret = _main(src, "t.py", ext=".pyx", no_pycodestyle=True, ban_relative_imports=True)
+    ret = _main(
+        src,
+        "t.py",
+        SharedState(),
+        ext=".pyx",
+        no_pycodestyle=True,
+        ban_relative_imports=True,
+    )
     out, _ = capsys.readouterr()
     assert out == expected
     assert ret == 1
 
-    ret = _main(src, "t.py", ext=".pyx", no_pycodestyle=True)
+    ret = _main(src, "t.py", SharedState(), ext=".pyx", no_pycodestyle=True)
     out, _ = capsys.readouterr()
     assert out == ""
     assert ret == 0
@@ -174,7 +189,7 @@ def test_pointless_string_statement(
     src: str,
     expected: str,
 ) -> None:
-    ret = _main(src, "t.py", ext=".pyx", no_pycodestyle=True)
+    ret = _main(src, "t.py", SharedState(), ext=".pyx", no_pycodestyle=True)
     out, _ = capsys.readouterr()
     assert out == expected
     assert ret == 1
@@ -202,7 +217,7 @@ def test_pointless_string_statement(
     ],
 )
 def test_unnecessary_index(capsys: Any, src: str, expected: str) -> None:
-    ret = _main(src, "t.py", ext=".pyx", no_pycodestyle=True)
+    ret = _main(src, "t.py", SharedState(), ext=".pyx", no_pycodestyle=True)
     out, _ = capsys.readouterr()
     assert out == expected
     assert ret == 1
@@ -226,7 +241,7 @@ def test_unnecessary_index(capsys: Any, src: str, expected: str) -> None:
     ],
 )
 def test_for_loop_variable_overwritten(capsys: Any, src: str, expected: str) -> None:
-    ret = _main(src, "t.py", ext=".pyx", no_pycodestyle=True)
+    ret = _main(src, "t.py", SharedState(), ext=".pyx", no_pycodestyle=True)
     out, _ = capsys.readouterr()
     assert out == expected
     assert ret == 1
@@ -234,7 +249,7 @@ def test_for_loop_variable_overwritten(capsys: Any, src: str, expected: str) -> 
 
 def test_for_loop_underscore_variable_no_violation(capsys: Any) -> None:
     src = "for _ in range(10):\n    for _ in range(5):\n        pass\n"
-    ret = _main(src, "t.py", ext=".pyx", no_pycodestyle=True)
+    ret = _main(src, "t.py", SharedState(), ext=".pyx", no_pycodestyle=True)
     out, _ = capsys.readouterr()
     assert out == ""
     assert ret == 0
@@ -243,7 +258,7 @@ def test_for_loop_underscore_variable_no_violation(capsys: Any) -> None:
 def test_for_loop_list_target_no_violation(capsys: Any) -> None:
     # list-unpacking target (ListNode) is not NameNode or TupleNode — hits else: pass
     src = "for [x, y] in items:\n    pass\n"
-    ret = _main(src, "t.py", ext=".pyx", no_pycodestyle=True)
+    ret = _main(src, "t.py", SharedState(), ext=".pyx", no_pycodestyle=True)
     out, _ = capsys.readouterr()
     assert out == ""
     assert ret == 0
@@ -282,7 +297,7 @@ def test_for_loop_list_target_no_violation(capsys: Any) -> None:
     ],
 )
 def test_loop_control_var_unused(capsys: Any, src: str, expected: str) -> None:
-    ret = _main(src, "t.py", ext=".pyx", no_pycodestyle=True)
+    ret = _main(src, "t.py", SharedState(), ext=".pyx", no_pycodestyle=True)
     out, _ = capsys.readouterr()
     assert out == expected
     assert ret == 1
@@ -310,7 +325,7 @@ def test_misplaced_comma_old_cython(
     src: str,
     expected: str,
 ) -> None:  # pragma: no cover
-    ret = _main(src, "t.py", ext=".pyx", no_pycodestyle=True)
+    ret = _main(src, "t.py", SharedState(), ext=".pyx", no_pycodestyle=True)
     out, _ = capsys.readouterr()
     assert out == expected
     assert ret == 1
@@ -330,7 +345,7 @@ def test_f_string_not_formatted(
     src: str,
     expected: str,
 ) -> None:
-    ret = _main(src, "t.py", ext=".pyx", no_pycodestyle=True)
+    ret = _main(src, "t.py", SharedState(), ext=".pyx", no_pycodestyle=True)
     out, _ = capsys.readouterr()
     assert out == expected
     assert ret == 1
@@ -354,7 +369,7 @@ def test_shadows_import(
     src: str,
     expected: str,
 ) -> None:
-    ret = _main(src, "t.py", ext=".pyx", no_pycodestyle=True)
+    ret = _main(src, "t.py", SharedState(), ext=".pyx", no_pycodestyle=True)
     out, _ = capsys.readouterr()
     if tuple(Cython.__version__.split(".")) < ("3",):  # pragma: no cover
         # old Cython records the location slightly differently
@@ -378,7 +393,7 @@ def test_repeated_set_element(
     src: str,
     expected: str,
 ) -> None:
-    ret = _main(src, "t.py", ext=".pyx", no_pycodestyle=True)
+    ret = _main(src, "t.py", SharedState(), ext=".pyx", no_pycodestyle=True)
     out, _ = capsys.readouterr()
     assert out == expected
     assert ret == 1
@@ -402,7 +417,7 @@ def test_repeated_dict_keys(
     src: str,
     expected: str,
 ) -> None:
-    ret = _main(src, "t.py", ext=".pyx", no_pycodestyle=True)
+    ret = _main(src, "t.py", SharedState(), ext=".pyx", no_pycodestyle=True)
     out, _ = capsys.readouterr()
     assert out == expected
     assert ret == 1
@@ -426,7 +441,7 @@ def test_dangerous_default(
     src: str,
     expected: str,
 ) -> None:
-    ret = _main(src, "t.py", ext=".pyx", no_pycodestyle=True)
+    ret = _main(src, "t.py", SharedState(), ext=".pyx", no_pycodestyle=True)
     out, _ = capsys.readouterr()
     assert out == expected
     assert ret == 1
@@ -457,7 +472,7 @@ def test_always_true(
     src: str,
     expected: str,
 ) -> None:
-    ret = _main(src, "t.py", ext=".pyx", no_pycodestyle=True)
+    ret = _main(src, "t.py", SharedState(), ext=".pyx", no_pycodestyle=True)
     out, _ = capsys.readouterr()
     assert out == expected
     assert ret == 1
@@ -481,7 +496,7 @@ def test_constants_comparison(
     src: str,
     expected: str,
 ) -> None:
-    ret = _main(src, "t.py", ext=".pyx", no_pycodestyle=True)
+    ret = _main(src, "t.py", SharedState(), ext=".pyx", no_pycodestyle=True)
     out, _ = capsys.readouterr()
     assert out == expected
     assert ret == 1
@@ -509,7 +524,7 @@ def test_strip_repeated_elements(
     src: str,
     expected: str,
 ) -> None:
-    ret = _main(src, "t.py", ext=".pyx", no_pycodestyle=True)
+    ret = _main(src, "t.py", SharedState(), ext=".pyx", no_pycodestyle=True)
     out, _ = capsys.readouterr()
     assert out == expected
     assert ret == 1
@@ -549,7 +564,7 @@ def test_late_binding_closure(
     src: str,
     expected: str,
 ) -> None:
-    ret = _main(src, "t.py", ext=".pyx", no_pycodestyle=True)
+    ret = _main(src, "t.py", SharedState(), ext=".pyx", no_pycodestyle=True)
     out, _ = capsys.readouterr()
     assert out == expected
     assert ret == 1
@@ -586,7 +601,7 @@ def test_pycodestyle(
     with open(os.path.join(tmpdir, "tox.ini"), "w") as fd:
         fd.write("[pycodestyle]\nstatistics=True\n")
     src = ""
-    ret = _main(src, file, ext=".pxd", ignore=ignore)
+    ret = _main(src, file, SharedState(), ext=".pxd", ignore=ignore)
     out, _ = capsys.readouterr()
 
     assert out == expected.format(file)
@@ -612,7 +627,7 @@ def test_pycodestyle_when_ast_parsing_fails(
         fd.write(src)
     with open(os.path.join(tmpdir, "tox.ini"), "w") as fd:
         fd.write("[pycodestyle]\nstatistics=True\n")
-    ret = _main(src, file, ext=".pyx")
+    ret = _main(src, file, SharedState(), ext=".pyx")
     out, _ = capsys.readouterr()
     assert f"Skipping file {file}, as it cannot be parsed. Error: CompileError" in out
     assert f"{file}:4:11: E231 missing whitespace after ':'\n" in out
@@ -726,7 +741,7 @@ def test_pycodestyle_when_ast_parsing_fails(
     ],
 )
 def test_noop(capsys: Any, src: str) -> None:
-    ret = _main(src, "test.py", ext=".pyx")
+    ret = _main(src, "test.py", SharedState(), ext=".pyx")
     out, _ = capsys.readouterr()
     assert out == ""
     assert ret == 0
@@ -741,7 +756,7 @@ def test_noop(capsys: Any, src: str) -> None:
     reason="invalid syntax in new Cython",
 )
 def test_noop_old_cython(capsys: Any, src: str) -> None:  # pragma: no cover
-    ret = _main(src, "t.py", ext=".pyx", no_pycodestyle=True)
+    ret = _main(src, "t.py", SharedState(), ext=".pyx", no_pycodestyle=True)
     out, _ = capsys.readouterr()
     assert out == ""
     assert ret == 0
@@ -842,7 +857,7 @@ def test_exported_imports(
     capsys: Any,
 ) -> None:
     src = 'import numpy\nimport polars\n__all__ = ["numpy", "os", 3]\n'
-    ret = _main(src, "t.py", ext=".pyx", no_pycodestyle=True)
+    ret = _main(src, "t.py", SharedState(), ext=".pyx", no_pycodestyle=True)
     out, _ = capsys.readouterr()
     expected = "t.py:2:8: 'polars' imported but unused\n"
     assert out == expected
@@ -871,7 +886,42 @@ def test_unnecessary_dict_list_set(
     src: str,
     expected: str,
 ) -> None:
-    ret = _main(src, "t.py", ext=".pyx", no_pycodestyle=True)
+    ret = _main(src, "t.py", SharedState(), ext=".pyx", no_pycodestyle=True)
     out, _ = capsys.readouterr()
     assert out == expected
     assert ret == 1
+
+
+def test_inline_pxd(tmp_path, capsys):
+    pyx = str(tmp_path / "example.pyx")
+    pxd = str(tmp_path / "example.pxd")
+
+    with open(pxd, "w") as f:
+        f.write("""\
+cdef int not_inline(int a)
+
+cdef int is_inline(int a)
+
+cdef inline int inline_in_pxd(int a):
+    return a
+""")
+
+    with open(pyx, "w") as f:
+        f.write("""
+cdef int not_inline(int a):
+    return a
+
+cdef inline int is_inline(int a):
+    return a
+""")
+
+    for ordered_files, lineno in [((pyx, pxd), 3), ((pxd, pyx), 5)]:
+        main(ordered_files)
+        out, _ = capsys.readouterr()
+        assert "inline_in_pxd" not in out
+        assert "not_inline" not in out
+        assert (
+            f"{ordered_files[1]}:{lineno}:0: C function 'is_inline' "
+            f"is declared in {pxd}:3, and implemented and marked inline in "
+            f"{pyx}:5."
+        ) in out

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -962,3 +962,26 @@ cdef class X2:
             f"is declared in {pxd}:3, and implemented and marked inline in "
             f"{pyx}:7."
         ) in out
+
+
+def test_cpp_pxd(capsys: Any, tmp_path: Path) -> None:
+    """Ensure parsing C++ pxd files doesn't result in a parsing error."""
+    pxd = str(tmp_path / "example.pxd")
+    with open(pxd, "w") as f:
+        f.write("""
+cdef extern from "arrow/util/iterator.h" namespace "arrow" nogil:
+    cdef cppclass CIterator" arrow::Iterator"[T]:
+        CResult[T] Next()
+        CStatus Visit[Visitor](Visitor&& visitor)
+        cppclass RangeIterator:
+            CResult[T] operator*()
+            RangeIterator& operator++()
+            c_bool operator!=(RangeIterator) const
+        RangeIterator begin()
+        RangeIterator end()
+    CIterator[T] MakeVectorIterator[T](vector[T] v)
+""")
+    main([pxd])
+    out, err = capsys.readouterr()
+    assert out == ""
+    assert err == ""


### PR DESCRIPTION
Fixes #197 

Does the following:

* Added a new lint.
* Linting is now run on `.pxd` files, which it wasn't before. This is... probably a good idea? Since you can have functions fully defined in a .pxd, kinda want them linted too. Might want to add .pxi too eventually.
* Not user facing, there is now a place for shared state for linting across files.

Known issue that I don't understand: some `.pxd` files in sklearn fail to parse. To be fair, I don't understand the syntax myself... but I suspect there's some way to tell cython it's a pxd that isn't being used?

E.g. `sklearn/utils/_sorting.pxd` fails with "CompileError((<StringSourceDescriptor:/home/itamarst/devel/scikit-learn/sklearn/utils/_sorting.pxd>, 9, 34), 'Expected an identifier or literal')"

Here's what `_sorting.pxd` looks like; I don't understand line 9 myself. Maybe it's "there's a default but I won't tell you what it is?" I don't know.

```cython
from sklearn.utils._typedefs cimport intp_t

from cython cimport floating

cdef void simultaneous_sort(
    floating* values,
    intp_t* indices,
    intp_t n,
    bint use_three_way_partition=*,  # <--- what is that * --itamarst
) noexcept nogil
```