### PR TITLE
Fix/dict comprehension cython 3.3

### DIFF
--- a/cython_lint/cython_lint.py
+++ b/cython_lint/cython_lint.py
@@ -106,7 +106,7 @@ EXCLUDES = (
     r")/"
 )
 
-if CYTHON_VERSION >= CYTHON_3:  # pragma: no cover
+if CYTHON_VERSION >= CYTHON_3:
     from Cython.Compiler.ExprNodes import AnnotationNode  # type: ignore[assignment]
 else:  # pragma: no cover
 

--- a/cython_lint/cython_lint.py
+++ b/cython_lint/cython_lint.py
@@ -77,15 +77,19 @@ from Cython.Compiler.Nodes import SingleAssignmentNode
 from Cython.Compiler.Nodes import StatListNode
 from Cython.Compiler.Nodes import StatNode
 from Cython.Compiler.TreeFragment import parse_from_strings
-from packaging.version import Version
 from tokenize_rt import src_to_tokens
 from tokenize_rt import tokens_to_src
 
 from cython_lint import __version__
 
-CYTHON_VERSION = Version(Cython.__version__)  # type: ignore[attr-defined]
-CYTHON_3 = Version("3")
-CYTHON_3_3 = Version("3.3")
+# non-numeric parts (e.g. the 'b1' of '3.1.0b1') are dropped
+CYTHON_VERSION = tuple(
+    int(part)
+    for part in Cython.__version__.split(".")  # type: ignore[attr-defined]
+    if part.isdigit()
+)
+CYTHON_3 = (3,)
+CYTHON_3_3 = (3, 3)
 if TYPE_CHECKING:
     from collections.abc import Hashable
     from collections.abc import Iterator

--- a/cython_lint/cython_lint.py
+++ b/cython_lint/cython_lint.py
@@ -346,7 +346,7 @@ def _args_from_sequence_node(node: SequenceNode) -> list[ExprNode]:
 def _value_from_dict_comprehension_append_node(
     node: DictComprehensionAppendNode,
 ) -> ExprNode:
-    if CYTHON_VERSION >= CYTHON_3_3:  # pragma: no cover
+    if CYTHON_VERSION >= CYTHON_3_3:
         # Cython 3.3 replaced key_expr/value_expr with a single DictItemNode
         return node.dict_item.value  # type: ignore[attr-defined]
     return node.value_expr  # type: ignore[attr-defined]  # pragma: no cover

--- a/cython_lint/cython_lint.py
+++ b/cython_lint/cython_lint.py
@@ -77,12 +77,15 @@ from Cython.Compiler.Nodes import SingleAssignmentNode
 from Cython.Compiler.Nodes import StatListNode
 from Cython.Compiler.Nodes import StatNode
 from Cython.Compiler.TreeFragment import parse_from_strings
+from packaging.version import Version
 from tokenize_rt import src_to_tokens
 from tokenize_rt import tokens_to_src
 
 from cython_lint import __version__
 
-CYTHON_VERSION = tuple(Cython.__version__.split("."))  # type: ignore[attr-defined]
+CYTHON_VERSION = Version(Cython.__version__)  # type: ignore[attr-defined]
+CYTHON_3 = Version("3")
+CYTHON_3_3 = Version("3.3")
 if TYPE_CHECKING:
     from collections.abc import Hashable
     from collections.abc import Iterator
@@ -99,7 +102,7 @@ EXCLUDES = (
     r")/"
 )
 
-if CYTHON_VERSION > ("3",):  # pragma: no cover
+if CYTHON_VERSION >= CYTHON_3:  # pragma: no cover
     from Cython.Compiler.ExprNodes import AnnotationNode  # type: ignore[assignment]
 else:  # pragma: no cover
 
@@ -334,6 +337,15 @@ def _target_from_for_in_stat_node(node: ForInStatNode) -> SequenceNode:
 
 def _args_from_sequence_node(node: SequenceNode) -> list[ExprNode]:
     return node.args  # type: ignore[attr-defined]
+
+
+def _value_from_dict_comprehension_append_node(
+    node: DictComprehensionAppendNode,
+) -> ExprNode:
+    if CYTHON_VERSION >= CYTHON_3_3:  # pragma: no cover
+        # Cython 3.3 replaced key_expr/value_expr with a single DictItemNode
+        return node.dict_item.value  # type: ignore[attr-defined]
+    return node.value_expr  # type: ignore[attr-defined]  # pragma: no cover
 
 
 def _rhs_from_single_assignment_node(node: SingleAssignmentNode) -> ExprNode:
@@ -629,7 +641,7 @@ def _traverse_file(  # noqa: PLR0915,PLR0913
             )
 
         if isinstance(node, (IfClauseNode, AssertStatNode)):
-            if CYTHON_VERSION > ("3",) or isinstance(
+            if CYTHON_VERSION >= CYTHON_3 or isinstance(
                 node, IfClauseNode
             ):  # pragma: no cover
                 test = isinstance(node.condition, TupleNode)
@@ -683,13 +695,13 @@ def _traverse_file(  # noqa: PLR0915,PLR0913
             and isinstance(node.loop.body, ComprehensionAppendNode)
         ):
             if isinstance(node.loop.body, DictComprehensionAppendNode):
-                expr = node.loop.body.value_expr
+                _expr = _value_from_dict_comprehension_append_node(node.loop.body)
             else:
-                expr = node.loop.body.expr
-            if isinstance(expr, LambdaNode) and not hasattr(expr, "loop"):
+                _expr = node.loop.body.expr
+            if isinstance(_expr, LambdaNode) and not hasattr(_expr, "loop"):
                 # GeneratorExpressionNode is a LambdaNode, and has a loop
                 # attribute, so need to exclude it.
-                _children = [j.node for j in traverse(expr)]
+                _children = [j.node for j in traverse(_expr)]
                 _names = [
                     _name_from_name_node(_child)
                     for _child in _children

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
 ]
 dependencies = [
   "cython>=0.29.32",
+  "packaging",
   "pycodestyle",
   "tokenize-rt>=3.2.0",
   "tomli;python_version<'3.11'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ classifiers = [
 ]
 dependencies = [
   "cython>=0.29.32",
-  "packaging",
   "pycodestyle",
   "tokenize-rt>=3.2.0",
   "tomli;python_version<'3.11'",

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -556,6 +556,22 @@ def test_late_binding_closure(
 
 
 @pytest.mark.parametrize(
+    "src",
+    [
+        "def f(seq):\n    return [x for x in seq]\n",
+        "def f(seq):\n    return {x for x in seq}\n",
+        "def f(seq):\n    return {x: x for x in seq}\n",
+        "def f(seq):\n    return {k: v for k, v in seq}\n",
+    ],
+)
+def test_comprehension_without_late_binding_closure(capsys: Any, src: str) -> None:
+    ret = _main(src, "t.py", ext=".pyx", no_pycodestyle=True)
+    out, _ = capsys.readouterr()
+    assert out == ""
+    assert ret == 0
+
+
+@pytest.mark.parametrize(
     ("ignore", "expected", "exp_ret"),
     [
         (


### PR DESCRIPTION
Fixes #201 

Cython 3.3 replaced the `key_expr`/`value_expr` children of `DictComprehensionAppendNode` with a single `dict_item` child (a `DictItemNode` with `key`/`value`), which made cython-lint crash with `AttributeError` on any dict comprehension with a single, non-tuple loop target.
    
- add `_value_from_dict_comprehension_append_node` helper that selects the attribute layout based on a Cython version check
- depend on `packaging` and compare `packaging.version.Version` objects instead of raw string tuples, which compared incorrectly for multi-digit version segments (e.g. `3.10` sorted before `3.3`)